### PR TITLE
fix: 解决 toolbar 放置 popover 组件中不显示

### DIFF
--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -8,6 +8,9 @@ export default Vue.extend({
     return h('div', { ref: 'box' });
   },
   props: ['editor', 'defaultConfig', 'mode'],
+  mounted () {
+    this.create(this.editor);
+  },
   methods: {
     // 创建 toolbar
     create(editor: any) {


### PR DESCRIPTION
toolbar 放置popover组件中，创建时机不对
```
<template>
  <Popover placement="topLeft" trigger="click">
    <template slot="content">
      <Toolbar :mode="mode" :editor="editor" />
    </template>
    <Editor
      :defaultConfig="editorConfig"
      :value="value"
      @onChange="onEditorChange"
      @onCreated="onCreated"
    />
  </Popover>
</template>

<script>
import { Popover } from 'ant-design-vue';
import { Editor, Toolbar } from '@wangeditor/editor-for-vue';

export default {
  components: { Popover, Editor, Toolbar },
  props: {
    value: {
      type: String,
      default: '',
    },
    onChange: {
      type: Function,
    },
  },
  data() {
    return {
      editor: null,
      mode: 'simple',
      editorConfig: {
        placeholder: '请输入内容...',
      },
    };
  },
  methods: {
    onCreated(editor) {
      this.editor = Object.seal(editor);
    },
    onEditorChange(editor) {
      this.onChange(editor.getHtml());
    },
  },
  beforeDestroy() {
    const editor = this.editor;
    if (editor == null) return;
    editor.destroy();
  },
};
</script>
```